### PR TITLE
herokuでrake assets:precompileが落ちないようにする

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -55,5 +55,8 @@ module GistMail
 
     # Version of your assets, change this if you want to expire all your assets
     config.assets.version = '1.0'
+
+    # https://devcenter.heroku.com/articles/rails3x-asset-pipeline-cedar
+    config.assets.initialize_on_precompile = false
   end
 end


### PR DESCRIPTION
[finish #39751951]
assets precompileを遅らせて実行

herokuにdeployして、deploy時のrake assets:precompileでエラーが出なければok
