### PR TITLE
Herokuでだけ1.9.3決め打ちにする

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '1.9.3'
+ruby '1.9.3' if ENV['HEROKU_POSTGRESQL_AMBER_URL'] # heroku specific
 gem 'rails', '3.2.11'
 
 # Bundle edge Rails instead:


### PR DESCRIPTION
herokuで動いているかどうか一意に分かる方法は現在無いので
HEROKU_POSTGRESQL_XXXXX_URL で代替
XXXXX部分はherokuのサーバーごとに異なる
